### PR TITLE
issue 35 shell support

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: serv/
     ports:
       - "8000:8000"
+      - "9001:9001"
+      - "12345:12345"
     depends_on:
       - pgdb
     networks:

--- a/docker/serv/Dockerfile
+++ b/docker/serv/Dockerfile
@@ -1,4 +1,4 @@
-FROM mshulha/snort3-python3:0.1
+FROM mshulha/snort3-python3:0.3
 
 COPY event-monitor-snort3 /usr/src/event-monitor-snort3
 

--- a/docker/serv/configs/custom_snort.lua
+++ b/docker/serv/configs/custom_snort.lua
@@ -19,3 +19,25 @@ alert_json =
     fields = 'gid sid rev timestamp src_addr src_port dst_addr dst_port proto action msg',
     file = true
 }
+
+perf_monitor = {  
+    modules = { },
+    base = true,
+    packets = 1,
+    seconds = 5,
+    output = file, 
+    format = json,    
+    summary = false, 
+}
+
+profiler = {
+  modules = {
+    show = false
+  },
+  memory = {
+    show = false
+  },
+  rules = {
+    count = 10
+  }
+}

--- a/docker/serv/configs/supervisord.conf
+++ b/docker/serv/configs/supervisord.conf
@@ -4,6 +4,15 @@ logfile = /tmp/supervisord.log
 logfile_maxbytes = 50MB
 loglevel = info
 
+[supervisorctl]
+serverurl=http://0.0.0.0:9001
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[inet_http_server]
+port = 0.0.0.0:9001
+
 [program:cron]
 command=cron -f
 autostart=true
@@ -24,7 +33,7 @@ directory=/usr/src/event-monitor-snort3/snort3_monitor
 startretries=3
 
 [program:snort]
-command=/usr/local/bin/snort -c ../configs/custom_snort.lua -i eth0 -A json -y -s 65535 -k none
+command=/usr/local/bin/snort --shell -c ../configs/custom_snort.lua -i eth0 -A json -y -s 65535 -k none -j 12345
 autostart=true
 autorestart=true
 directory=/usr/src/event-monitor-snort3/snort_logs

--- a/snort3_monitor/api/snort_telnet.py
+++ b/snort3_monitor/api/snort_telnet.py
@@ -1,0 +1,23 @@
+from telnetlib import Telnet
+
+
+def execute_snort_command(command):
+    """
+    Execute a Snort command in an interactive shell via Telnet.
+
+    :param command: The command to be executed.
+    :return: The response from the Telnet server.
+    """
+    try:
+        with Telnet('127.0.0.1', 12345) as tn:
+
+            tn.read_until(b'\n')
+
+            tn.write(command.encode('ascii') + b'\n')
+
+            response = tn.read_until(b'o")~', timeout=30).decode('ascii')
+
+            return response
+
+    except Exception as e:
+        return f"Error: {e}"

--- a/snort3_monitor/api/urls.py
+++ b/snort3_monitor/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import EventsList, EventsCount, RequestList, RulesList
+from .views import EventsList, EventsCount, RequestList, RulesList, ExecuteCommand
 
 
 urlpatterns = [
@@ -8,4 +8,6 @@ urlpatterns = [
     path('events/count', EventsCount.as_view(), name='events_count'),
     path('requests-log', RequestList.as_view()),
     path('rules', RulesList.as_view(), name='rules_list'),
+    path('execute', ExecuteCommand.as_view(), name='execute_command'),
+
 ]

--- a/snort3_monitor/api/views.py
+++ b/snort3_monitor/api/views.py
@@ -13,6 +13,7 @@ from rest_framework import status
 from event.models import Rule, Event
 from request.models import RequestLog
 from .serializers import EventSerializer, SidCountSerializer, AddrCountSerializer, RequestSerializer, RuleSerializer
+from .snort_telnet import execute_snort_command
 
 
 MIN_PORT, MAX_PORT = 0, 65535
@@ -273,3 +274,22 @@ class RequestList(APIView, PageNumberPagination):
                 "message": "The period must be less than a week"
             }
             return Response(content, status=status.HTTP_400_BAD_REQUEST)
+
+
+class ExecuteCommand(APIView):
+    """
+       API endpoint for executing Snort commands.
+
+       This class provides a POST method to execute Snort commands received in the request payload.
+       The 'command' parameter is expected in the request data.
+
+       Returns response from Snort received via Telnet or error if no command was provided.
+    """
+    def post(self, request):
+        command = self.request.data.get('command', None)
+
+        if command is not None:
+            response = execute_snort_command(command)
+            return Response({"response": response})
+        else:
+            return Response({"error": "No command provided."})


### PR DESCRIPTION
Issue #35 

Configured running snort in shell mode with telnet enabled and api to send command to Snort's interactive shell and return captured output. 
Updated custom snort lua config with perf_monitor and profiler configurations
Updated supervisord config for supervisorctl to run correctly